### PR TITLE
add renderer to conflictedComponents

### DIFF
--- a/addon/utils/components.js
+++ b/addon/utils/components.js
@@ -2,7 +2,10 @@ import AFrame from 'aframe';
 
 const { components } = AFrame;
 
-export const conflictedComponents = ['layout'];
+export const conflictedComponents = [
+  'layout',
+  'renderer'
+];
 
 function filter(components) {
   return components.filter(c => !conflictedComponents.includes(c));


### PR DESCRIPTION
Closes #83.

Discovered by @evoactivity (Thanks!).

`renderer` is in use internally https://github.com/emberjs/ember.js/blob/v3.4.0/packages/ember-glimmer/lib/component.ts#L576, so we must exclude it.